### PR TITLE
feat: Add pause menu and controls remapping system

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,0 @@
-Issue to solve: https://github.com/Jhon-Crow/godot-topdown-template/issues/7
-Your prepared branch: issue-7-97b70de0bffc
-Your prepared working directory: /tmp/gh-issue-solver-1768157532672
-Your forked repository: konard/Jhon-Crow-godot-topdown-template
-Original repository (upstream): Jhon-Crow/godot-topdown-template
-
-Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,7 @@
+Issue to solve: https://github.com/Jhon-Crow/godot-topdown-template/issues/7
+Your prepared branch: issue-7-97b70de0bffc
+Your prepared working directory: /tmp/gh-issue-solver-1768157532672
+Your forked repository: konard/Jhon-Crow-godot-topdown-template
+Original repository (upstream): Jhon-Crow/godot-topdown-template
+
+Proceed.

--- a/README.md
+++ b/README.md
@@ -32,17 +32,23 @@ godot-topdown-template/
 │   ├── objects/           # Game object scenes
 │   │   └── Target.tscn    # Shootable target
 │   └── ui/                # UI scenes
+│       ├── PauseMenu.tscn # Pause menu with resume/controls/quit
+│       └── ControlsMenu.tscn # Key rebinding interface
 ├── scripts/               # GDScript files (.gd)
 │   ├── main.gd            # Main scene script
 │   ├── levels/            # Level scripts
 │   │   └── test_tier.gd   # Test tier script
 │   ├── autoload/          # Autoload/singleton scripts
+│   │   └── input_settings.gd # Input settings manager (singleton)
 │   ├── characters/        # Character scripts
 │   │   └── player.gd      # Player movement and shooting script
 │   ├── projectiles/       # Projectile scripts
 │   │   └── bullet.gd      # Bullet behavior script
 │   ├── objects/           # Game object scripts
 │   │   └── target.gd      # Target hit reaction script
+│   ├── ui/                # UI scripts
+│   │   ├── pause_menu.gd  # Pause menu controller
+│   │   └── controls_menu.gd # Key rebinding controller
 │   └── utils/             # Utility scripts
 ├── assets/                # Game assets
 │   ├── sprites/           # 2D sprites and textures
@@ -162,6 +168,41 @@ A shootable target that reacts when hit by bullets. Features:
 - **Layer**: 6 (targets)
 - **Mask**: 5 (projectiles) - targets detect bullets
 
+### PauseMenu.tscn
+A pause menu that appears when pressing Escape during gameplay. Features:
+- **Resume** - Return to gameplay
+- **Controls** - Open the key rebinding menu
+- **Quit** - Exit the game
+- Pauses the game tree when visible
+- Works during gameplay in any level
+
+### ControlsMenu.tscn
+A key rebinding interface accessible from the pause menu. Features:
+- **Action list** - Shows all remappable actions with current key bindings
+- **Rebinding** - Click any action button and press a new key to reassign
+- **Conflict detection** - Warns when a key is already assigned to another action
+- **Apply/Reset/Back** - Save changes, reset to defaults, or return to pause menu
+- **Persistent settings** - Key bindings are saved to `user://input_settings.cfg`
+
+#### Remappable Actions
+| Action | Default Key | Description |
+|--------|-------------|-------------|
+| Move Up | W | Move player upward |
+| Move Down | S | Move player downward |
+| Move Left | A | Move player left |
+| Move Right | D | Move player right |
+| Shoot | Left Mouse Button | Fire projectile towards cursor |
+| Pause | Escape | Toggle pause menu |
+
+#### Using the Controls Menu
+1. Press Escape to open the pause menu
+2. Click "Controls" to open the key rebinding menu
+3. Click any action button to start rebinding
+4. Press the desired new key (or Escape to cancel)
+5. Click "Apply" to save changes
+6. Click "Reset" to restore default bindings
+7. Click "Back" to return to the pause menu
+
 ## Input Actions
 
 The project includes pre-configured input actions for top-down movement:
@@ -173,6 +214,7 @@ The project includes pre-configured input actions for top-down movement:
 | `move_left` | A, Left Arrow |
 | `move_right` | D, Right Arrow |
 | `shoot` | Left Mouse Button |
+| `pause` | Escape |
 
 ## Physics Layers
 

--- a/project.godot
+++ b/project.godot
@@ -8,6 +8,10 @@
 
 config_version=5
 
+[autoload]
+
+InputSettings="*res://scripts/autoload/input_settings.gd"
+
 [application]
 
 config/name="Godot Top-Down Template"
@@ -54,6 +58,11 @@ move_right={
 shoot={
 "deadzone": 0.5,
 "events": [Object(InputEventMouseButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"button_mask":1,"position":Vector2(0, 0),"global_position":Vector2(0, 0),"factor":1.0,"button_index":1,"canceled":false,"pressed":true,"double_click":false,"script":null)
+]
+}
+pause={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194305,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
 ]
 }
 

--- a/scenes/levels/TestTier.tscn
+++ b/scenes/levels/TestTier.tscn
@@ -1,8 +1,9 @@
-[gd_scene load_steps=8 format=3 uid="uid://d3kv7pm5r2aub"]
+[gd_scene load_steps=9 format=3 uid="uid://d3kv7pm5r2aub"]
 
 [ext_resource type="Script" path="res://scripts/levels/test_tier.gd" id="1_test_tier"]
 [ext_resource type="PackedScene" uid="uid://bk8nq2vj5r7p1" path="res://scenes/characters/Player.tscn" id="2_player"]
 [ext_resource type="PackedScene" uid="uid://bx3k7pm5t2aub" path="res://scenes/objects/Target.tscn" id="3_target"]
+[ext_resource type="PackedScene" uid="uid://dxqmk8f3nw5pe" path="res://scenes/ui/PauseMenu.tscn" id="4_pause_menu"]
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_wall_horizontal"]
 size = Vector2(800, 32)
@@ -196,6 +197,8 @@ layout_mode = 1
 anchors_preset = 0
 offset_left = 10.0
 offset_top = 650.0
-offset_right = 400.0
+offset_right = 450.0
 offset_bottom = 710.0
-text = "WASD / Arrow Keys - Move | LMB - Shoot | Red squares - Targets | Brown - Walls/Obstacles"
+text = "WASD / Arrow Keys - Move | LMB - Shoot | ESC - Pause"
+
+[node name="PauseMenu" parent="." instance=ExtResource("4_pause_menu")]

--- a/scenes/ui/ControlsMenu.tscn
+++ b/scenes/ui/ControlsMenu.tscn
@@ -1,0 +1,90 @@
+[gd_scene load_steps=2 format=3 uid="uid://bhk3y7v2nw8qf"]
+
+[ext_resource type="Script" path="res://scripts/ui/controls_menu.gd" id="1_controls"]
+
+[node name="ControlsMenu" type="CanvasLayer"]
+layer = 101
+process_mode = 2
+script = ExtResource("1_controls")
+
+[node name="MenuContainer" type="Control" parent="."]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="PanelContainer" type="PanelContainer" parent="MenuContainer"]
+layout_mode = 1
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -250.0
+offset_top = -200.0
+offset_right = 250.0
+offset_bottom = 200.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="MarginContainer" type="MarginContainer" parent="MenuContainer/PanelContainer"]
+layout_mode = 2
+theme_override_constants/margin_left = 20
+theme_override_constants/margin_top = 20
+theme_override_constants/margin_right = 20
+theme_override_constants/margin_bottom = 20
+
+[node name="VBoxContainer" type="VBoxContainer" parent="MenuContainer/PanelContainer/MarginContainer"]
+layout_mode = 2
+theme_override_constants/separation = 15
+
+[node name="TitleLabel" type="Label" parent="MenuContainer/PanelContainer/MarginContainer/VBoxContainer"]
+layout_mode = 2
+text = "Controls"
+horizontal_alignment = 1
+
+[node name="Separator" type="HSeparator" parent="MenuContainer/PanelContainer/MarginContainer/VBoxContainer"]
+layout_mode = 2
+
+[node name="ScrollContainer" type="ScrollContainer" parent="MenuContainer/PanelContainer/MarginContainer/VBoxContainer"]
+custom_minimum_size = Vector2(0, 200)
+layout_mode = 2
+size_flags_vertical = 3
+
+[node name="ActionList" type="VBoxContainer" parent="MenuContainer/PanelContainer/MarginContainer/VBoxContainer/ScrollContainer"]
+layout_mode = 2
+size_flags_horizontal = 3
+theme_override_constants/separation = 10
+
+[node name="StatusLabel" type="Label" parent="MenuContainer/PanelContainer/MarginContainer/VBoxContainer"]
+custom_minimum_size = Vector2(0, 30)
+layout_mode = 2
+horizontal_alignment = 1
+vertical_alignment = 1
+
+[node name="ButtonContainer" type="HBoxContainer" parent="MenuContainer/PanelContainer/MarginContainer/VBoxContainer"]
+layout_mode = 2
+alignment = 1
+theme_override_constants/separation = 10
+
+[node name="ApplyButton" type="Button" parent="MenuContainer/PanelContainer/MarginContainer/VBoxContainer/ButtonContainer"]
+custom_minimum_size = Vector2(100, 35)
+layout_mode = 2
+text = "Apply"
+
+[node name="ResetButton" type="Button" parent="MenuContainer/PanelContainer/MarginContainer/VBoxContainer/ButtonContainer"]
+custom_minimum_size = Vector2(100, 35)
+layout_mode = 2
+text = "Reset"
+
+[node name="BackButton" type="Button" parent="MenuContainer/PanelContainer/MarginContainer/VBoxContainer/ButtonContainer"]
+custom_minimum_size = Vector2(100, 35)
+layout_mode = 2
+text = "Back"
+
+[node name="ConflictDialog" type="AcceptDialog" parent="."]
+title = "Key Conflict"
+initial_position = 1
+size = Vector2i(300, 100)

--- a/scenes/ui/PauseMenu.tscn
+++ b/scenes/ui/PauseMenu.tscn
@@ -1,0 +1,59 @@
+[gd_scene load_steps=2 format=3 uid="uid://dxqmk8f3nw5pe"]
+
+[ext_resource type="Script" path="res://scripts/ui/pause_menu.gd" id="1_pause"]
+
+[node name="PauseMenu" type="CanvasLayer"]
+layer = 100
+process_mode = 2
+script = ExtResource("1_pause")
+
+[node name="ColorRect" type="ColorRect" parent="."]
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+color = Color(0, 0, 0, 0.5)
+
+[node name="MenuContainer" type="Control" parent="."]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="VBoxContainer" type="VBoxContainer" parent="MenuContainer"]
+layout_mode = 1
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -100.0
+offset_top = -100.0
+offset_right = 100.0
+offset_bottom = 100.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_constants/separation = 20
+
+[node name="TitleLabel" type="Label" parent="MenuContainer/VBoxContainer"]
+layout_mode = 2
+text = "PAUSED"
+horizontal_alignment = 1
+
+[node name="ResumeButton" type="Button" parent="MenuContainer/VBoxContainer"]
+custom_minimum_size = Vector2(200, 40)
+layout_mode = 2
+text = "Resume"
+
+[node name="ControlsButton" type="Button" parent="MenuContainer/VBoxContainer"]
+custom_minimum_size = Vector2(200, 40)
+layout_mode = 2
+text = "Controls"
+
+[node name="QuitButton" type="Button" parent="MenuContainer/VBoxContainer"]
+custom_minimum_size = Vector2(200, 40)
+layout_mode = 2
+text = "Quit"

--- a/scripts/autoload/input_settings.gd
+++ b/scripts/autoload/input_settings.gd
@@ -1,0 +1,233 @@
+extends Node
+## Autoload singleton for managing input settings and key bindings.
+##
+## Handles saving and loading key bindings from a configuration file.
+## Provides functionality for remapping controls and resetting to defaults.
+
+## Path to the settings configuration file.
+const SETTINGS_PATH := "user://input_settings.cfg"
+
+## Configuration file for storing settings.
+var _config := ConfigFile.new()
+
+## List of action names that can be remapped.
+var remappable_actions: Array[String] = [
+	"move_up",
+	"move_down",
+	"move_left",
+	"move_right",
+	"shoot",
+	"pause"
+]
+
+## Default key bindings stored at startup before any user modifications.
+var _default_bindings: Dictionary = {}
+
+## Signal emitted when controls are changed.
+signal controls_changed
+
+
+func _ready() -> void:
+	_store_default_bindings()
+	_ensure_pause_action_exists()
+	load_settings()
+
+
+## Ensures the pause action exists in InputMap (may not be defined by default).
+func _ensure_pause_action_exists() -> void:
+	if not InputMap.has_action("pause"):
+		InputMap.add_action("pause")
+		var event := InputEventKey.new()
+		event.physical_keycode = KEY_ESCAPE
+		InputMap.action_add_event("pause", event)
+
+
+## Stores the default bindings from InputMap at startup.
+func _store_default_bindings() -> void:
+	for action_name in remappable_actions:
+		if InputMap.has_action(action_name):
+			var events := InputMap.action_get_events(action_name)
+			_default_bindings[action_name] = events.duplicate()
+
+
+## Loads settings from the configuration file.
+func load_settings() -> void:
+	var err := _config.load(SETTINGS_PATH)
+	if err != OK:
+		return  # No settings file exists yet, use defaults
+
+	for action_name in remappable_actions:
+		if not _config.has_section_key("controls", action_name):
+			continue
+
+		var saved_key: int = _config.get_value("controls", action_name, 0)
+		if saved_key == 0:
+			continue
+
+		# Clear existing events and add the saved one
+		_set_action_key(action_name, saved_key)
+
+	controls_changed.emit()
+
+
+## Saves current settings to the configuration file.
+func save_settings() -> void:
+	for action_name in remappable_actions:
+		var events := InputMap.action_get_events(action_name)
+		for event in events:
+			if event is InputEventKey:
+				var key_event: InputEventKey = event
+				var keycode := key_event.physical_keycode
+				if keycode == 0:
+					keycode = key_event.keycode
+				_config.set_value("controls", action_name, keycode)
+				break
+			elif event is InputEventMouseButton:
+				# For mouse buttons, save as negative values to distinguish
+				var mouse_event: InputEventMouseButton = event
+				_config.set_value("controls", action_name, -mouse_event.button_index)
+				break
+
+	var err := _config.save(SETTINGS_PATH)
+	if err != OK:
+		push_error("Failed to save input settings: " + str(err))
+
+
+## Sets a new key for an action.
+func set_action_key(action_name: String, event: InputEvent) -> void:
+	if not action_name in remappable_actions:
+		return
+
+	# Remove the old events
+	InputMap.action_erase_events(action_name)
+
+	# Add the new event
+	InputMap.action_add_event(action_name, event)
+
+	controls_changed.emit()
+
+
+## Internal method to set action key from physical keycode.
+func _set_action_key(action_name: String, keycode: int) -> void:
+	if not InputMap.has_action(action_name):
+		InputMap.add_action(action_name)
+
+	InputMap.action_erase_events(action_name)
+
+	if keycode < 0:
+		# Negative values indicate mouse buttons
+		var mouse_event := InputEventMouseButton.new()
+		mouse_event.button_index = -keycode
+		mouse_event.pressed = true
+		InputMap.action_add_event(action_name, mouse_event)
+	else:
+		var key_event := InputEventKey.new()
+		key_event.physical_keycode = keycode
+		InputMap.action_add_event(action_name, key_event)
+
+
+## Resets all controls to their default values.
+func reset_to_defaults() -> void:
+	for action_name in remappable_actions:
+		if action_name in _default_bindings:
+			InputMap.action_erase_events(action_name)
+			for event in _default_bindings[action_name]:
+				InputMap.action_add_event(action_name, event)
+
+	save_settings()
+	controls_changed.emit()
+
+
+## Gets the display name for an input event.
+func get_event_name(event: InputEvent) -> String:
+	if event is InputEventKey:
+		var key_event: InputEventKey = event
+		var keycode := key_event.physical_keycode
+		if keycode == 0:
+			keycode = key_event.keycode
+		return OS.get_keycode_string(keycode)
+	elif event is InputEventMouseButton:
+		var mouse_event: InputEventMouseButton = event
+		match mouse_event.button_index:
+			MOUSE_BUTTON_LEFT:
+				return "Left Mouse"
+			MOUSE_BUTTON_RIGHT:
+				return "Right Mouse"
+			MOUSE_BUTTON_MIDDLE:
+				return "Middle Mouse"
+			MOUSE_BUTTON_WHEEL_UP:
+				return "Mouse Wheel Up"
+			MOUSE_BUTTON_WHEEL_DOWN:
+				return "Mouse Wheel Down"
+			_:
+				return "Mouse " + str(mouse_event.button_index)
+	return "Unknown"
+
+
+## Gets the first event assigned to an action.
+func get_action_event(action_name: String) -> InputEvent:
+	if not InputMap.has_action(action_name):
+		return null
+	var events := InputMap.action_get_events(action_name)
+	if events.size() > 0:
+		return events[0]
+	return null
+
+
+## Gets the display name for an action's current binding.
+func get_action_key_name(action_name: String) -> String:
+	var event := get_action_event(action_name)
+	if event:
+		return get_event_name(event)
+	return "Not Set"
+
+
+## Gets a human-readable name for an action.
+func get_action_display_name(action_name: String) -> String:
+	match action_name:
+		"move_up":
+			return "Move Up"
+		"move_down":
+			return "Move Down"
+		"move_left":
+			return "Move Left"
+		"move_right":
+			return "Move Right"
+		"shoot":
+			return "Shoot"
+		"pause":
+			return "Pause"
+		_:
+			return action_name.capitalize().replace("_", " ")
+
+
+## Checks if a key is already assigned to another action.
+## Returns the action name if conflict exists, empty string otherwise.
+func check_key_conflict(event: InputEvent, exclude_action: String = "") -> String:
+	for action_name in remappable_actions:
+		if action_name == exclude_action:
+			continue
+
+		var action_event := get_action_event(action_name)
+		if action_event == null:
+			continue
+
+		if _events_match(event, action_event):
+			return action_name
+
+	return ""
+
+
+## Checks if two input events match.
+func _events_match(event1: InputEvent, event2: InputEvent) -> bool:
+	if event1 is InputEventKey and event2 is InputEventKey:
+		var key1: InputEventKey = event1
+		var key2: InputEventKey = event2
+		var keycode1 := key1.physical_keycode if key1.physical_keycode != 0 else key1.keycode
+		var keycode2 := key2.physical_keycode if key2.physical_keycode != 0 else key2.keycode
+		return keycode1 == keycode2
+	elif event1 is InputEventMouseButton and event2 is InputEventMouseButton:
+		var mouse1: InputEventMouseButton = event1
+		var mouse2: InputEventMouseButton = event2
+		return mouse1.button_index == mouse2.button_index
+	return false

--- a/scripts/ui/controls_menu.gd
+++ b/scripts/ui/controls_menu.gd
@@ -1,0 +1,253 @@
+extends CanvasLayer
+## Controls menu for remapping game key bindings.
+##
+## Displays a list of all remappable actions with their current key bindings.
+## Allows users to rebind keys by clicking on an action and pressing a new key.
+## Includes conflict detection and settings persistence.
+
+## Signal emitted when the back button is pressed.
+signal back_pressed
+
+## Reference to the action list container.
+@onready var action_list: VBoxContainer = $MenuContainer/PanelContainer/MarginContainer/VBoxContainer/ScrollContainer/ActionList
+@onready var apply_button: Button = $MenuContainer/PanelContainer/MarginContainer/VBoxContainer/ButtonContainer/ApplyButton
+@onready var reset_button: Button = $MenuContainer/PanelContainer/MarginContainer/VBoxContainer/ButtonContainer/ResetButton
+@onready var back_button: Button = $MenuContainer/PanelContainer/MarginContainer/VBoxContainer/ButtonContainer/BackButton
+@onready var status_label: Label = $MenuContainer/PanelContainer/MarginContainer/VBoxContainer/StatusLabel
+@onready var conflict_dialog: AcceptDialog = $ConflictDialog
+
+## Currently selected action for rebinding. Empty string means no action selected.
+var _rebinding_action: String = ""
+
+## Dictionary mapping action names to their UI button references.
+var _action_buttons: Dictionary = {}
+
+## Flag to track if there are unsaved changes.
+var _has_changes: bool = false
+
+## Temporary storage for new bindings before applying.
+var _pending_bindings: Dictionary = {}
+
+
+func _ready() -> void:
+	# Connect button signals
+	apply_button.pressed.connect(_on_apply_pressed)
+	reset_button.pressed.connect(_on_reset_pressed)
+	back_button.pressed.connect(_on_back_pressed)
+	conflict_dialog.confirmed.connect(_on_conflict_confirmed)
+
+	# Populate the action list
+	_populate_action_list()
+
+	# Update button states
+	_update_button_states()
+
+	# Set process mode to allow input while paused
+	process_mode = Node.PROCESS_MODE_ALWAYS
+
+
+func _populate_action_list() -> void:
+	# Clear existing children (except template if any)
+	for child in action_list.get_children():
+		child.queue_free()
+	_action_buttons.clear()
+
+	# Create a row for each remappable action
+	for action_name in InputSettings.remappable_actions:
+		var row := _create_action_row(action_name)
+		action_list.add_child(row)
+
+
+func _create_action_row(action_name: String) -> HBoxContainer:
+	var row := HBoxContainer.new()
+	row.name = action_name + "_row"
+
+	# Action name label
+	var label := Label.new()
+	label.text = InputSettings.get_action_display_name(action_name)
+	label.custom_minimum_size.x = 150
+	label.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	row.add_child(label)
+
+	# Key binding button
+	var button := Button.new()
+	button.name = action_name + "_button"
+	button.text = InputSettings.get_action_key_name(action_name)
+	button.custom_minimum_size = Vector2(150, 35)
+	button.pressed.connect(_on_action_button_pressed.bind(action_name))
+	row.add_child(button)
+
+	_action_buttons[action_name] = button
+
+	return row
+
+
+func _input(event: InputEvent) -> void:
+	if _rebinding_action.is_empty():
+		return
+
+	# Only handle key and mouse button events
+	if not (event is InputEventKey or event is InputEventMouseButton):
+		return
+
+	# Ignore key release events
+	if event is InputEventKey and not event.pressed:
+		return
+
+	# Ignore mouse button release events
+	if event is InputEventMouseButton and not event.pressed:
+		return
+
+	# Prevent the event from propagating
+	get_viewport().set_input_as_handled()
+
+	# Handle escape key to cancel rebinding
+	if event is InputEventKey and event.physical_keycode == KEY_ESCAPE:
+		_cancel_rebinding()
+		return
+
+	# Check for conflicts
+	var conflict := InputSettings.check_key_conflict(event, _rebinding_action)
+	if not conflict.is_empty():
+		_show_conflict_dialog(conflict, event)
+		return
+
+	# Apply the new binding
+	_apply_pending_binding(_rebinding_action, event)
+
+
+func _on_action_button_pressed(action_name: String) -> void:
+	_start_rebinding(action_name)
+
+
+func _start_rebinding(action_name: String) -> void:
+	_rebinding_action = action_name
+
+	# Update button text to show waiting state
+	var button: Button = _action_buttons[action_name]
+	button.text = "Press a key..."
+
+	# Update status
+	status_label.text = "Press a key for " + InputSettings.get_action_display_name(action_name) + " (Escape to cancel)"
+
+
+func _cancel_rebinding() -> void:
+	if _rebinding_action.is_empty():
+		return
+
+	# Restore the button text
+	var button: Button = _action_buttons[_rebinding_action]
+	if _rebinding_action in _pending_bindings:
+		button.text = InputSettings.get_event_name(_pending_bindings[_rebinding_action])
+	else:
+		button.text = InputSettings.get_action_key_name(_rebinding_action)
+
+	_rebinding_action = ""
+	status_label.text = ""
+
+
+func _apply_pending_binding(action_name: String, event: InputEvent) -> void:
+	# Store in pending bindings
+	_pending_bindings[action_name] = event
+
+	# Update button text
+	var button: Button = _action_buttons[action_name]
+	button.text = InputSettings.get_event_name(event)
+
+	# Mark as having unsaved changes
+	_has_changes = true
+	_update_button_states()
+
+	# Clear rebinding state
+	_rebinding_action = ""
+	status_label.text = "Changes pending. Click Apply to save."
+
+
+func _show_conflict_dialog(conflicting_action: String, new_event: InputEvent) -> void:
+	var conflict_name := InputSettings.get_action_display_name(conflicting_action)
+	var key_name := InputSettings.get_event_name(new_event)
+
+	conflict_dialog.dialog_text = "'" + key_name + "' is already assigned to '" + conflict_name + "'.\n\nDo you want to replace it?"
+
+	# Store the event for when confirmed
+	conflict_dialog.set_meta("pending_event", new_event)
+	conflict_dialog.set_meta("conflicting_action", conflicting_action)
+
+	conflict_dialog.popup_centered()
+
+
+func _on_conflict_confirmed() -> void:
+	var pending_event: InputEvent = conflict_dialog.get_meta("pending_event")
+	var conflicting_action: String = conflict_dialog.get_meta("conflicting_action")
+
+	# Clear the conflicting action's binding
+	_pending_bindings[conflicting_action] = null
+	var conflict_button: Button = _action_buttons[conflicting_action]
+	conflict_button.text = "Not Set"
+
+	# Apply the new binding
+	_apply_pending_binding(_rebinding_action, pending_event)
+
+
+func _on_apply_pressed() -> void:
+	# Apply all pending bindings
+	for action_name in _pending_bindings:
+		var event: InputEvent = _pending_bindings[action_name]
+		if event != null:
+			InputSettings.set_action_key(action_name, event)
+		else:
+			# Clear the action
+			InputMap.action_erase_events(action_name)
+
+	# Save settings
+	InputSettings.save_settings()
+
+	# Clear pending changes
+	_pending_bindings.clear()
+	_has_changes = false
+	_update_button_states()
+
+	status_label.text = "Settings saved!"
+
+	# Clear status after a delay
+	await get_tree().create_timer(2.0).timeout
+	if status_label.text == "Settings saved!":
+		status_label.text = ""
+
+
+func _on_reset_pressed() -> void:
+	# Reset to defaults
+	InputSettings.reset_to_defaults()
+
+	# Clear pending changes
+	_pending_bindings.clear()
+	_has_changes = false
+
+	# Refresh the UI
+	_refresh_all_buttons()
+	_update_button_states()
+
+	status_label.text = "Controls reset to defaults."
+
+
+func _on_back_pressed() -> void:
+	# If there are unsaved changes, discard them
+	if _has_changes:
+		_pending_bindings.clear()
+		_has_changes = false
+		_refresh_all_buttons()
+
+	_rebinding_action = ""
+	status_label.text = ""
+
+	back_pressed.emit()
+
+
+func _refresh_all_buttons() -> void:
+	for action_name in _action_buttons:
+		var button: Button = _action_buttons[action_name]
+		button.text = InputSettings.get_action_key_name(action_name)
+
+
+func _update_button_states() -> void:
+	apply_button.disabled = not _has_changes

--- a/scripts/ui/pause_menu.gd
+++ b/scripts/ui/pause_menu.gd
@@ -1,0 +1,92 @@
+extends CanvasLayer
+## Pause menu controller.
+##
+## Handles game pausing and provides access to controls menu and resume/quit options.
+## This menu pauses the game tree when visible.
+
+## Reference to the controls menu scene.
+@export var controls_menu_scene: PackedScene
+
+## Reference to the main menu container.
+@onready var menu_container: Control = $MenuContainer
+@onready var resume_button: Button = $MenuContainer/VBoxContainer/ResumeButton
+@onready var controls_button: Button = $MenuContainer/VBoxContainer/ControlsButton
+@onready var quit_button: Button = $MenuContainer/VBoxContainer/QuitButton
+
+## The instantiated controls menu.
+var _controls_menu: CanvasLayer = null
+
+
+func _ready() -> void:
+	# Start hidden
+	hide()
+	set_process_unhandled_input(true)
+
+	# Connect button signals
+	resume_button.pressed.connect(_on_resume_pressed)
+	controls_button.pressed.connect(_on_controls_pressed)
+	quit_button.pressed.connect(_on_quit_pressed)
+
+	# Preload controls menu if not set
+	if controls_menu_scene == null:
+		controls_menu_scene = preload("res://scenes/ui/ControlsMenu.tscn")
+
+
+func _unhandled_input(event: InputEvent) -> void:
+	if event.is_action_pressed("pause"):
+		toggle_pause()
+		get_viewport().set_input_as_handled()
+
+
+## Toggles the pause state.
+func toggle_pause() -> void:
+	if visible:
+		resume_game()
+	else:
+		pause_game()
+
+
+## Pauses the game and shows the menu.
+func pause_game() -> void:
+	get_tree().paused = true
+	show()
+	resume_button.grab_focus()
+
+
+## Resumes the game and hides the menu.
+func resume_game() -> void:
+	get_tree().paused = false
+	hide()
+
+	# Also close controls menu if open
+	if _controls_menu and _controls_menu.visible:
+		_controls_menu.hide()
+
+
+func _on_resume_pressed() -> void:
+	resume_game()
+
+
+func _on_controls_pressed() -> void:
+	# Hide main menu, show controls menu
+	menu_container.hide()
+
+	if _controls_menu == null:
+		_controls_menu = controls_menu_scene.instantiate()
+		_controls_menu.back_pressed.connect(_on_controls_back)
+		add_child(_controls_menu)
+	else:
+		_controls_menu.show()
+
+
+func _on_controls_back() -> void:
+	# Show main menu again
+	if _controls_menu:
+		_controls_menu.hide()
+	menu_container.show()
+	controls_button.grab_focus()
+
+
+func _on_quit_pressed() -> void:
+	get_tree().paused = false
+	get_tree().quit()


### PR DESCRIPTION
## Summary

This PR implements a complete pause menu system with key rebinding functionality as requested in #7.

### Features Added

- **InputSettings Autoload** (`scripts/autoload/input_settings.gd`)
  - Singleton for managing input settings
  - Saves/loads key bindings from `user://input_settings.cfg`
  - Supports key conflict detection
  - Reset to defaults functionality

- **PauseMenu** (`scenes/ui/PauseMenu.tscn`)
  - Resume button - returns to gameplay
  - Controls button - opens key rebinding menu
  - Quit button - exits the game
  - Pauses game tree when visible
  - Triggers via ESC key

- **ControlsMenu** (`scenes/ui/ControlsMenu.tscn`)
  - Displays all remappable actions with current bindings
  - Click-to-rebind interface
  - Conflict detection with confirmation dialog
  - Apply/Reset/Back buttons
  - Pending changes system (changes only saved on Apply)

### Remappable Actions
- Move Up (default: W)
- Move Down (default: S)
- Move Left (default: A)
- Move Right (default: D)
- Shoot (default: Left Mouse Button)
- Pause (default: Escape)

### Integration
- PauseMenu integrated into TestTier level
- Added `pause` action to project input map
- Updated README with documentation

## Test Plan
- [ ] Press ESC during gameplay to open pause menu
- [ ] Click Resume to continue playing
- [ ] Open Controls menu and rebind a key
- [ ] Verify conflict detection when assigning duplicate keys
- [ ] Click Apply and verify settings persist after restart
- [ ] Click Reset to restore default bindings
- [ ] Click Quit to exit the game

Fixes #7

---
*Generated with [Claude Code](https://claude.com/claude-code)*