### PR TITLE
Добавить сборку в portable exe в GitHub Actions

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -1,0 +1,33 @@
+name: Build Windows Portable EXE
+
+on:
+  push:
+    branches: [ main, issue-* ]
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
+
+jobs:
+  export-windows:
+    name: Windows Export
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Export game
+        id: export
+        uses: firebelley/godot-export@v7.0.0
+        with:
+          godot_executable_download_url: https://github.com/godotengine/godot/releases/download/4.3-stable/Godot_v4.3-stable_linux.x86_64.zip
+          godot_export_templates_download_url: https://github.com/godotengine/godot/releases/download/4.3-stable/Godot_v4.3-stable_export_templates.tpz
+          relative_project_path: ./
+          archive_output: true
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-build
+          path: ${{ steps.export.outputs.archive_directory }}/*

--- a/.gitignore
+++ b/.gitignore
@@ -32,4 +32,4 @@ Thumbs.db
 .vscode/
 
 # Export files
-export_presets.cfg
+# export_presets.cfg - commented out to allow CI/CD builds

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,0 @@
-Issue to solve: https://github.com/Jhon-Crow/godot-topdown-template/issues/11
-Your prepared branch: issue-11-e44fc9203a1d
-Your prepared working directory: /tmp/gh-issue-solver-1768158650987
-Your forked repository: konard/Jhon-Crow-godot-topdown-template
-Original repository (upstream): Jhon-Crow/godot-topdown-template
-
-Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,7 @@
+Issue to solve: https://github.com/Jhon-Crow/godot-topdown-template/issues/11
+Your prepared branch: issue-11-e44fc9203a1d
+Your prepared working directory: /tmp/gh-issue-solver-1768158650987
+Your forked repository: konard/Jhon-Crow-godot-topdown-template
+Original repository (upstream): Jhon-Crow/godot-topdown-template
+
+Proceed.

--- a/export_presets.cfg
+++ b/export_presets.cfg
@@ -1,0 +1,67 @@
+[preset.0]
+
+name="Windows Desktop"
+platform="Windows Desktop"
+runnable=true
+advanced_options=false
+dedicated_server=false
+custom_features=""
+export_filter="all_resources"
+include_filter=""
+exclude_filter=""
+export_path="builds/windows/Godot-Top-Down-Template.exe"
+encryption_include_filters=""
+encryption_exclude_filters=""
+encrypt_pck=false
+encrypt_directory=false
+
+script_encryption_key=""
+
+[preset.0.options]
+
+custom_template/debug=""
+custom_template/release=""
+debug/export_console_wrapper=1
+binary_format/embed_pck=true
+texture_format/bptc=true
+texture_format/s3tc=true
+texture_format/etc=false
+texture_format/etc2=false
+binary_format/architecture="x86_64"
+codesign/enable=false
+codesign/timestamp=true
+codesign/timestamp_server_url=""
+codesign/digest_algorithm=1
+codesign/description=""
+codesign/custom_options=PackedStringArray()
+application/modify_resources=true
+application/icon=""
+application/console_wrapper_icon=""
+application/icon_interpolation=4
+application/file_version=""
+application/product_version=""
+application/company_name=""
+application/product_name="Godot Top-Down Template"
+application/file_description=""
+application/copyright=""
+application/trademarks=""
+application/export_angle=0
+application/export_d3d12=0
+application/d3d12_agility_sdk_multiarch=true
+ssh_remote_deploy/enabled=false
+ssh_remote_deploy/host="user@host_ip"
+ssh_remote_deploy/port="22"
+ssh_remote_deploy/extra_args_ssh=""
+ssh_remote_deploy/extra_args_scp=""
+ssh_remote_deploy/run_script="Expand-Archive -LiteralPath '{temp_dir}\\{archive_name}' -DestinationPath '{temp_dir}'
+$action = New-ScheduledTaskAction -Execute '{temp_dir}\\{exe_name}' -Argument '{cmd_args}'
+$trigger = New-ScheduledTaskTrigger -Once -At 00:00
+$settings = New-ScheduledTaskSettingsSet
+$task = New-ScheduledTask -Action $action -Trigger $trigger -Settings $settings
+Register-ScheduledTask godot_remote_debug -InputObject $task -Force:$true
+Start-ScheduledTask -TaskName godot_remote_debug
+while (Get-ScheduledTask -TaskName godot_remote_debug | ? State -eq running) { Start-Sleep -Milliseconds 100 }
+Unregister-ScheduledTask -TaskName godot_remote_debug -Confirm:$false -ErrorAction:SilentlyContinue"
+ssh_remote_deploy/cleanup_script="Stop-ScheduledTask -TaskName godot_remote_debug -ErrorAction:SilentlyContinue
+Unregister-ScheduledTask -TaskName godot_remote_debug -Confirm:$false -ErrorAction:SilentlyContinue
+Remove-Item -Recurse -Force '{temp_dir}'"


### PR DESCRIPTION
## 📋 Описание / Description

Добавлена автоматическая сборка Windows portable exe через GitHub Actions.

Added automatic Windows portable exe build through GitHub Actions.

### 🔧 Что реализовано / What's Implemented

1. **GitHub Actions Workflow** (`.github/workflows/build-windows.yml`)
   - Автоматическая сборка при push в main и ветки issue-*
   - Автоматическая сборка при создании Pull Request
   - Возможность ручного запуска через workflow_dispatch
   - Использует Godot 4.3-stable с официальных релизов GitHub
   - Создаёт архив с готовой сборкой

2. **Конфигурация экспорта** (`export_presets.cfg`)
   - Настроен пресет "Windows Desktop"
   - x86_64 архитектура
   - Embedded PCK для портативности
   - Поддержка современных текстурных форматов (S3TC, BPTC)

3. **Обновление .gitignore**
   - Разрешено коммитить export_presets.cfg для CI/CD

### 📦 Артефакты сборки / Build Artifacts

После каждой успешной сборки доступен артефакт `windows-build` содержащий:
- `Godot-Top-Down-Template.exe` - готовый к запуску исполняемый файл
- Все необходимые ресурсы игры встроены в .exe (embedded PCK)

Артефакты можно скачать на странице Actions конкретного workflow run.

### ✅ Проверено / Tested

- ✅ Workflow успешно запускается
- ✅ Godot 4.3-stable загружается и устанавливается
- ✅ Export templates загружаются корректно
- ✅ Проект успешно экспортируется в Windows exe
- ✅ Артефакт корректно загружается (размер: ~29 MB)
- ✅ CI проходит без ошибок

### 🔗 Связанные ресурсы / Related Resources

- Issue: Jhon-Crow/godot-topdown-template#11
- CI Run: https://github.com/konard/Jhon-Crow-godot-topdown-template/actions/runs/20900479966

### 📝 Примечания / Notes

- Workflow использует [firebelley/godot-export@v7.0.0](https://github.com/marketplace/actions/godot-export)
- Загрузка Godot выполняется с официального GitHub релиза (не с tuxfamily)
- Сборка выполняется на Ubuntu latest runner
- Есть предупреждение о rcedit (для установки иконки), но оно не критично для функциональности

---
🤖 Создано автоматически с помощью [Claude Code](https://claude.com/claude-code)


Fixes Jhon-Crow/godot-topdown-template#11