### PR TITLE
fix: Change main scene to TestTier.tscn to enable gameplay

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,7 @@
+Issue to solve: https://github.com/Jhon-Crow/godot-topdown-template/issues/18
+Your prepared branch: issue-18-4002b53c0efa
+Your prepared working directory: /tmp/gh-issue-solver-1768159699568
+Your forked repository: konard/Jhon-Crow-godot-topdown-template
+Original repository (upstream): Jhon-Crow/godot-topdown-template
+
+Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,0 @@
-Issue to solve: https://github.com/Jhon-Crow/godot-topdown-template/issues/18
-Your prepared branch: issue-18-4002b53c0efa
-Your prepared working directory: /tmp/gh-issue-solver-1768159699568
-Your forked repository: konard/Jhon-Crow-godot-topdown-template
-Original repository (upstream): Jhon-Crow/godot-topdown-template
-
-Proceed.

--- a/project.godot
+++ b/project.godot
@@ -18,7 +18,7 @@ config/name="Godot Top-Down Template"
 config/description="A template project for creating top-down games in Godot 4.
 Includes basic project structure and example scenes."
 config/tags=PackedStringArray("2d", "template", "topdown")
-run/main_scene="res://scenes/main/Main.tscn"
+run/main_scene="res://scenes/levels/TestTier.tscn"
 config/features=PackedStringArray("4.3")
 config/icon="res://icon.svg"
 


### PR DESCRIPTION
## 🎯 Summary

This PR fixes the issues reported in #18 where:
1. The game doesn't start when pressing F5
2. The pause menu (ESC key) doesn't work during gameplay

## 🔍 Root Cause Analysis

The project had `Main.tscn` set as the main scene in `project.godot`, but this scene was just a placeholder template with instructions. It lacked:
- Actual gameplay elements (player, enemies, environment)
- Pause menu integration

The actual playable game with full functionality exists in `TestTier.tscn`, which includes:
- Player character with movement and shooting
- Game environment with walls and obstacles
- PauseMenu instance with ESC key support
- Proper scene structure for gameplay

## 🛠️ Changes Made

- **project.godot**: Changed `run/main_scene` from `"res://scenes/main/Main.tscn"` to `"res://scenes/levels/TestTier.tscn"`

## ✅ Testing

The fix addresses both issues:
1. ✅ Pressing F5 now starts the actual game (TestTier scene with player, environment, targets)
2. ✅ Pressing ESC during gameplay opens the pause menu (already implemented in TestTier.tscn)

## 📝 Related Issues

Fixes #18

---
*This PR was created by the AI issue solver*